### PR TITLE
add add_theme() to save a themes non-default rcParams to themes/theme_name.txt

### DIFF
--- a/themepy/theme.py
+++ b/themepy/theme.py
@@ -1,5 +1,6 @@
 import matplotlib as mpl
 from .set_theme import set_params, list_themes
+import os.path as path
 
 
 class Theme:
@@ -211,3 +212,31 @@ class Theme:
             raise KeyError("{} is not a valid arg. Must be 'both' or one of 'x' or 'y'".format(which))
 
         return self
+
+    def set_updated_rcparams(self):
+        """
+        sets the non-default rcParams to updated_params
+        """
+        self.updated_params = {}
+
+        for key, val in mpl.pyplot.rcParams.items():
+            default = mpl.rcParamsDefault[key]
+            if default != val:
+                self.updated_params[key] = val
+
+        if 'axes.prop_cycle' in self.updated_params:
+            cycler_ = self.updated_params.pop('axes.prop_cycle')
+            cycler_colors = cycler_.by_key()['color']
+            self.updated_params['cycler-prop-cycles'] = cycler_colors
+
+    def add_theme(self, theme_name):
+        """
+        saves the non-default params of the theme locally to /themes/[theme_name].txt
+
+        Input
+        =====
+            theme_name (string): the name of the theme
+        """
+        self.set_updated_rcparams()
+        with open(path.dirname(path.abspath(__file__))+'/themes/'+theme_name+'.txt', 'w') as file:
+            print(str(self.updated_params).replace(', ', ',\n'), file=file)


### PR DESCRIPTION
This PR adds the function add_theme() to theme.py to save a themes rcParams that differ from the matplotlib default rcParams to themes/theme_name.txt locally.

To do this, this PR also adds the function set_updated_rcparams to theme.py. It iters through the current rcParams, compares them to the default values, and stores the non-default values in theme.updated_params.

This allows us to easily save, share and reuse themes.

I hope this matches the intention you had for this function in the ToDo list, but feel free to correct me if I misunderstood this.
On second thought I wonder whether those functions would better belong in set_theme?

```
theme = themepy.Theme()

# set a theme with
# theme.set_theme(theme_name)
# set rcParams with
# theme.set_pips().set_spines() etc.
# or with
# mpl.rcParams[param] = value

# When happy with the theme, save it for future use.
theme.add_theme(theme_name)
```

An example of a saved theme by calling add_theme() looks like this:

> {'axes.edgecolor': '#969696',
'axes.facecolor': '#282c34',
'axes.grid': True,
'axes.labelcolor': '#f0f0f0',
'axes.labelsize': 12.0,
'axes.spines.bottom': False,
'axes.spines.left': False,
'axes.spines.right': False,
'axes.spines.top': False,
'axes.titlecolor': '#f0f0f0',
'figure.edgecolor': '#252526',
'figure.facecolor': '#252526',
'grid.color': '#737373',
'grid.linewidth': 0.5,
'legend.edgecolor': '#252526',
'legend.facecolor': '#252526',
'legend.frameon': False,
'savefig.bbox': 'tight',
'savefig.edgecolor': '#252526',
'savefig.facecolor': '#252526',
'text.color': 'w',
'xtick.color': '#969696',
'xtick.labelsize': 10.0,
'ytick.color': '#969696',
'ytick.labelsize': 10.0,
'cycler-prop-cycles': ['#aaff17',
'#ffaa00',
'#00e5ff',
'#fc68af',
'#fbff00',
'#ff2b2b',
'#0077ff',
'#d000ff',
'#00eb1b']}